### PR TITLE
Fixing use double-splats for hash parameters error

### DIFF
--- a/lib/jekyll/menus.rb
+++ b/lib/jekyll/menus.rb
@@ -100,7 +100,7 @@ module Jekyll
       # --
 
       if menu.is_a?(Array) || menu.is_a?(String)
-        _simple_front_matter_menu(menu, {
+        _simple_front_matter_menu(menu, **{
           :mergeable => out, :page => page
         })
 
@@ -127,7 +127,7 @@ module Jekyll
           # --
 
           elsif item.is_a?(Hash)
-            out[key] << _fill_front_matter_menu(item, {
+            out[key] << _fill_front_matter_menu(item, **{
               :page => page
             })
 
@@ -178,7 +178,7 @@ module Jekyll
 
       else
         mergeable[menu] ||= []
-        mergeable[menu] << _fill_front_matter_menu(nil, {
+        mergeable[menu] << _fill_front_matter_menu(nil, **{
           :page => page
         })
       end


### PR DESCRIPTION
Hi, as #18 is now an error when using Ruby 3.0.0 onwards I needed to address this issue locally.

As the change was very small, I wondered if this is something that could be merged into this main project as a 0.6.2 release so the existing Gem can be used, rather than making a forked version.