### PR TITLE
fix: Ruby 3.0 Argument Error

### DIFF
--- a/lib/jekyll/menus.rb
+++ b/lib/jekyll/menus.rb
@@ -116,7 +116,7 @@ module Jekyll
           # --
 
           if item.is_a?(String)
-            out[key] << _fill_front_matter_menu({ "identifier" => item }, {
+            out[key] << _fill_front_matter_menu({ "identifier" => item }, **{
               :page => page
             })
 
@@ -127,7 +127,7 @@ module Jekyll
           # --
 
           elsif item.is_a?(Hash)
-            out[key] << _fill_front_matter_menu(item, {
+            out[key] << _fill_front_matter_menu(item, **{
               :page => page
             })
 
@@ -178,7 +178,7 @@ module Jekyll
 
       else
         mergeable[menu] ||= []
-        mergeable[menu] << _fill_front_matter_menu(nil, {
+        mergeable[menu] << _fill_front_matter_menu(nil, **{
           :page => page
         })
       end


### PR DESCRIPTION
fix #21 

See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/