### PR TITLE
Update Gem.gemspec

### DIFF
--- a/Gem.gemspec
+++ b/Gem.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.email = ["jordon@envygeeks.io"]
   spec.require_paths = ["lib"]
   spec.name = "jekyll-menus"
-  spec.has_rdoc = false
   spec.license = "MIT"
 
   spec.add_runtime_dependency("jekyll", ">= 3.6", "< 5.0" )


### PR DESCRIPTION
Gem has_rdoc, which is deprecated in the latest RubyGems API.

Cause a warning message after doing bundle install or update.

